### PR TITLE
Fix/missing games after sort filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Website to visualize your [BGG](https://boardgamegeek.com/) collection to better
 1. `pnpm dev` to start the dev server
 1. Navigate to http://localhost:5173/
 
+### Troubleshoot
+
+If an expected game isn't showing up, then add `debug=1` to the query parameter to see the list of games as it goes through the different filters outputted to the console.
+
 ## Other Scripts
 
 These are the other scripts defined in `package.json`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bgg-what-to-play",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Website to visualize your BGG collection by player count recommendation.",
   "keywords": [
     "vite",

--- a/src/components/SearchFilterForm/BggCollection/BggCollection.utils.ts
+++ b/src/components/SearchFilterForm/BggCollection/BggCollection.utils.ts
@@ -59,14 +59,21 @@ const addIsPlayerCountWithinRange =
         minFilterCount,
         maxFilterCount
       ) ||
+      calcValueIsWithinRanage(
+        minFilterCount,
+        game.minPlayers,
+        game.maxPlayers
+      ) ||
       // handle edge case for id = 40567
       (filterState.showInvalidPlayerCount && game.minPlayers === 0);
 
-    const maxWithinRange = calcValueIsWithinRanage(
-      game.maxPlayers,
-      minFilterCount,
-      maxFilterCount
-    );
+    const maxWithinRange =
+      calcValueIsWithinRanage(
+        game.maxPlayers,
+        minFilterCount,
+        maxFilterCount
+      ) ||
+      calcValueIsWithinRanage(maxFilterCount, game.minPlayers, game.maxPlayers);
 
     return {
       ...game,

--- a/src/components/SearchFilterForm/BggCollection/BggCollection.utils.ts
+++ b/src/components/SearchFilterForm/BggCollection/BggCollection.utils.ts
@@ -1,6 +1,18 @@
 import type { CollectionFilterState } from "@/types";
 import type { SimpleBoardGame } from ".";
 
+const maybeOutputList =
+  (filterState: CollectionFilterState, groupLabel: string) =>
+  (game: SimpleBoardGame, index: number, array: SimpleBoardGame[]) => {
+    if (filterState.isDebug && index === 0) {
+      console.groupCollapsed(groupLabel);
+      console.table(array.map(({ id, name }) => ({ id, name })));
+      console.groupEnd();
+    }
+
+    return game;
+  };
+
 const maybeShowExpansions =
   (filterState: CollectionFilterState) => (game: SimpleBoardGame) => {
     if (filterState.showExpansions) return true;
@@ -112,10 +124,13 @@ export const applyFiltersAndSorts = (
   filterState: CollectionFilterState
 ) =>
   games
-    ?.filter(maybeShowExpansions(filterState))
+    ?.map(maybeOutputList(filterState, "All Games"))
+    .filter(maybeShowExpansions(filterState))
+    .map(maybeOutputList(filterState, "maybeShowExpansions"))
     .map(maybeShowInvalidPlayerCount(filterState))
     .map(addIsPlayerCountWithinRange(filterState))
     .filter((g) => g.isPlayerCountWithinRange) // Remove games not within Player Count Range
+    .map(maybeOutputList(filterState, "isPlayerCountWithinRange"))
     .sort(maybeSortByScore(filterState));
 
 export type BoardGame = ReturnType<typeof applyFiltersAndSorts>[number];

--- a/src/components/SearchFilterForm/BggCollection/GameCard/PlayerCountChart/PlayerCountChart.tsx
+++ b/src/components/SearchFilterForm/BggCollection/GameCard/PlayerCountChart/PlayerCountChart.tsx
@@ -13,6 +13,7 @@ import {
 import { AccessibleLabels } from "./AccessibleLabels";
 import { CustomTooltip } from "./CustomTooltip";
 import { MaybeNoDataAvailable } from "./MaybeNoDataAvailable";
+import { usePrefersReducedMotion } from "./usePrefersReducedMotion";
 
 type Recommendation = "Best" | "Recommended" | "Not Recommended";
 
@@ -48,6 +49,7 @@ export const PlayerCountChart = ({
   gameId,
 }: Props) => {
   const { ref, inView } = useInView();
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   return (
     <div ref={ref} className="h-36">
@@ -94,6 +96,7 @@ export const PlayerCountChart = ({
                     stackId="playerCount"
                     maxBarSize={32}
                     dataKey={recommendation}
+                    isAnimationActive={!prefersReducedMotion}
                   >
                     {recommendedPlayerCount.map(
                       (playerCount, playerCountIndex) => (

--- a/src/components/SearchFilterForm/BggCollection/GameCard/PlayerCountChart/usePrefersReducedMotion.ts
+++ b/src/components/SearchFilterForm/BggCollection/GameCard/PlayerCountChart/usePrefersReducedMotion.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+const query = "(prefers-reduced-motion: no-preference)";
+const getInitialState = () => !window.matchMedia(query).matches;
+
+export const usePrefersReducedMotion = () => {
+  const [prefersReducedMotion, setPrefersReducedMotion] =
+    useState(getInitialState);
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(query);
+    const listener = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(!event.matches);
+    };
+    mediaQueryList.addEventListener("change", listener);
+
+    return () => {
+      mediaQueryList.removeEventListener("change", listener);
+    };
+  }, []);
+
+  return prefersReducedMotion;
+};

--- a/src/components/SearchFilterForm/BggCollection/hooks/useGetCollectionQuery.utils.spec.ts
+++ b/src/components/SearchFilterForm/BggCollection/hooks/useGetCollectionQuery.utils.spec.ts
@@ -113,7 +113,7 @@ describe(transformToBoardGame.name, () => {
           "Recommended": 5,
           "playerCountValue": 1,
           "playerCountLabel": "1",
-          "sortScore": 1.84375,
+          "sortScore": 159,
         },
         {
           "Best": 5,
@@ -121,7 +121,7 @@ describe(transformToBoardGame.name, () => {
           "Recommended": 12,
           "playerCountValue": 2,
           "playerCountLabel": "2",
-          "sortScore": 0.857142857142857,
+          "sortScore": 80,
         },
         {
           "Best": 0,
@@ -129,7 +129,7 @@ describe(transformToBoardGame.name, () => {
           "Recommended": 5,
           "playerCountValue": 3,
           "playerCountLabel": "3",
-          "sortScore": -0.411764705882353,
+          "sortScore": -49,
         },
         {
           "Best": 0,
@@ -137,7 +137,7 @@ describe(transformToBoardGame.name, () => {
           "Recommended": 2,
           "playerCountValue": 4,
           "playerCountLabel": "4",
-          "sortScore": -0.7647058823529411,
+          "sortScore": -89,
         },
         {
           "Best": 0,
@@ -145,7 +145,7 @@ describe(transformToBoardGame.name, () => {
           "Recommended": 0,
           "playerCountValue": 5,
           "playerCountLabel": "4+",
-          "sortScore": -1,
+          "sortScore": -118,
         },
       ],
     };

--- a/src/components/SearchFilterForm/BggCollection/hooks/useGetCollectionQuery.utils.ts
+++ b/src/components/SearchFilterForm/BggCollection/hooks/useGetCollectionQuery.utils.ts
@@ -124,7 +124,10 @@ const addSortScore = (
   const bestPercent = i["Best"] / totalVotes;
   const recPercent = i["Recommended"] / totalVotes;
   const notRecPercent = i["Not Recommended"] / totalVotes;
-  const sortScore = bestPercent * 2 + recPercent - notRecPercent;
+  const maybeSortScore = bestPercent * 2 + recPercent - notRecPercent;
+  const sortScore = Number.isNaN(maybeSortScore)
+    ? Number.NEGATIVE_INFINITY
+    : maybeSortScore;
 
   return {
     ...i,

--- a/src/components/SearchFilterForm/BggCollection/hooks/useGetCollectionQuery.utils.ts
+++ b/src/components/SearchFilterForm/BggCollection/hooks/useGetCollectionQuery.utils.ts
@@ -118,21 +118,23 @@ const flattenSuggestedNumPlayersResult = ({
 });
 
 const addSortScore = (
-  i: ReturnType<typeof flattenSuggestedNumPlayersResult>
+  playerRec: ReturnType<typeof flattenSuggestedNumPlayersResult>
 ) => {
-  const totalVotes = i["Best"] + i["Recommended"] + i["Not Recommended"];
-  const bestPercent = i["Best"] / totalVotes;
-  const recPercent = i["Recommended"] / totalVotes;
-  const notRecPercent = i["Not Recommended"] / totalVotes;
-  const maybeSortScore = bestPercent * 2 + recPercent - notRecPercent;
-  const sortScore = Number.isNaN(maybeSortScore)
-    ? Number.NEGATIVE_INFINITY
-    : maybeSortScore;
+  const { Best, Recommended, ["Not Recommended"]: notRec } = playerRec;
+  const totalVotes = Best + Recommended + notRec;
+  const bestPercent = Math.round((Best * 100) / totalVotes + Best * 2);
+  const recPercent = Math.round((Recommended * 100) / totalVotes + Recommended);
+  const notRecPercent = Math.round((notRec * 100) / totalVotes + notRec);
+  const maybeSortScore = bestPercent + recPercent - notRecPercent;
+  const sortScore =
+    totalVotes === 0 || Number.isNaN(maybeSortScore)
+      ? Number.NEGATIVE_INFINITY
+      : maybeSortScore;
 
   return {
-    ...i,
+    ...playerRec,
 
-    /** 2xBest % + Recommended % - Not Recommended % */
+    /** 2xBest Raw + Best % + Recommended Raw + Recommended % - Not Recommended Row - Not Recommended % */
     sortScore,
   };
 };

--- a/src/components/SearchFilterForm/useCollectionFilters.ts
+++ b/src/components/SearchFilterForm/useCollectionFilters.ts
@@ -10,6 +10,7 @@ const QUERY_PARAMS = {
   PLAYER_COUNT: "playerCount",
   SHOW_INVALID_PLAYER_COUNT: "showInvalid",
   SHOW_EXPANSIONS: "showExpansions",
+  IS_DEBUG: "debug",
 } as const;
 
 type QueryParamKey = typeof QUERY_PARAMS[keyof typeof QUERY_PARAMS];
@@ -112,6 +113,9 @@ const initialFilterState = {
 
   /** If `true`, then show expansions in collection. */
   showExpansions: getQueryParamValue(QUERY_PARAMS.SHOW_EXPANSIONS) === "1",
+
+  /** If `true`, then `console.log` messages to help troubleshoot. */
+  isDebug: getQueryParamValue(QUERY_PARAMS.IS_DEBUG) === "1",
 };
 
 export type CollectionFilterState = typeof initialFilterState;


### PR DESCRIPTION
Features:
- [Add debug query parameter](https://github.com/davidhorm/bgg-what-to-play/commit/fc51e5b6c1c5575fe59cfe598fa9d6142d90fdba)
- [prefers-reduced-motion disables animation](https://github.com/davidhorm/bgg-what-to-play/commit/0e5d88d8cb916ab145f5ef224c395ca4d0a32b5a)
- [Update sortScore to consider raw number of votes](https://github.com/davidhorm/bgg-what-to-play/commit/792532cb69996bdb093217f9a6e22a15a5beffda)
- related fix: [sortScore with zero votes = negative infinity](https://github.com/davidhorm/bgg-what-to-play/commit/a1885e88df5ce95e9710903ac97d6bd47a5a2d46)

Fix:
- [addIsPlayerCountWithinRange accounts for narrow range](https://github.com/davidhorm/bgg-what-to-play/commit/83162e723bbfc78bf357be7a6ef2450f16e1347c)