### PR TITLE
chore: clean up test:ci

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm dlx playwright install --with-deps
       - name: Run Playwright tests
-        run: pnpm test:ci
+        run: pnpm test
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/package.json
+++ b/package.json
@@ -29,9 +29,8 @@
     "coverage": "vitest run --coverage",
     "test": "pnpm run test:unit run && pnpm run test:e2e",
     "test:unit": "vitest",
-    "test:e2e": "concurrently --kill-others \"vite\" \"pnpm dlx playwright test\"",
+    "test:e2e": "pnpm dlx playwright test",
     "codegen": "concurrently --kill-others \"vite\" \"pnpm dlx playwright codegen\"",
-    "test:ci": "pnpm run test:unit run && pnpm dlx playwright test",
     "predeploy": "pnpm run build",
     "deploy": "gh-pages -d dist"
   },


### PR DESCRIPTION
before I added `test:ci` because `concurrently` was breaking in pipelines. But `concurrently` was breaking locally too after adding the `webServer` in the playwright config. so we probably don't need `concurrently` anymore in `test:e2e` and therefore won't need `test:ci`.