### PR TITLE
fix: query limit to 20

### DIFF
--- a/src/components/BggCollection/hooks/useGetCollectionQuery.utils.ts
+++ b/src/components/BggCollection/hooks/useGetCollectionQuery.utils.ts
@@ -12,7 +12,7 @@ import type {
 const transformToThingIds = (i: Collection["items"]["item"][number]) =>
   i.objectid;
 
-const THING_QUERY_LIMIT = 1200;
+const THING_QUERY_LIMIT = 20; // TODO unit test. also render error in future
 
 const transformToUniqueChunks = (games?: Collection) =>
   _.chunk(


### PR DESCRIPTION
Hot Fix because of https://boardgamegeek.com/thread/3336313/max-20-items-from-xml-api-and-xml-api-2

FYI: e2e tests were failing because playwright didn't like `test.describe`. need to figure out later.

TODO:
- add unit testing
- render error message when API fails like that (instead of spinning forever)